### PR TITLE
feat: add `format` command and formatting options

### DIFF
--- a/.github/workflows/ts-internal.yml
+++ b/.github/workflows/ts-internal.yml
@@ -19,5 +19,5 @@ jobs:
   type-check:
     uses: voxpelli/ghatemplates/.github/workflows/type-check.yml@main
     with:
-      ts-versions: ${{ github.event.schedule && 'next' || '5.4,next' }}
+      ts-versions: ${{ github.event.schedule && 'next' || '5.5,next' }}
       ts-libs: 'es2022;esnext'

--- a/.github/workflows/ts-internal.yml
+++ b/.github/workflows/ts-internal.yml
@@ -19,5 +19,5 @@ jobs:
   type-check:
     uses: voxpelli/ghatemplates/.github/workflows/type-check.yml@main
     with:
-      ts-versions: ${{ github.event.schedule && 'next' || '5.5,next' }}
+      ts-versions: ${{ github.event.schedule && 'next' || '5.6,next' }}
       ts-libs: 'es2022;esnext'

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ list-dependents list installed-check > dependents.ndjson
 ## Commands
 
 * `list-dependents filter` – narrows down an existing list of modules
+* `list-dependents format` – pretty prints a list to the terminal or as markdown
 * `list-dependents list` – creates or updates list of dependent modules
 * `list-dependents refresh` – refreshes the data within a list of modules
 

--- a/lib/cli-types.d.ts
+++ b/lib/cli-types.d.ts
@@ -62,10 +62,11 @@ interface CommandContextNamed extends CommandContextBase {
   moduleName: string;
 }
 
-export interface CommandContextFilter extends CommandContextBase, FileContext, FilterFlags, SortFlags {
+export interface CommandContextFilter extends CommandContextBase, FileContext, FilterFlags, FormatContext, SortFlags {
   exclude: string[] | undefined;
   include: string[] | undefined;
   maxCount: number | undefined;
+  prettyPrint: boolean;
   repositoryPrefix: string[] | undefined;
   targetVersion: string | undefined;
 }

--- a/lib/cli-types.d.ts
+++ b/lib/cli-types.d.ts
@@ -23,9 +23,21 @@ export interface FilterFlags {
   minDownloads: number;
 }
 
+export interface FormatFlags {
+  markdown: boolean;
+  skipLinks: boolean;
+}
+
 interface InputContext {
   explicitInput: boolean;
   input: ReadStream | ReadStreamTTY | undefined;
+}
+
+interface OutputContext {
+  output: string | undefined;
+}
+
+interface FileContext extends InputContext, OutputContext {
   modifyInPlace: boolean;
 }
 
@@ -35,9 +47,14 @@ interface SortFlags {
   sortDownloads: boolean;
 }
 
+interface FormatContext {
+  markdown: boolean;
+  pkgFields: string[] | undefined;
+  skipLinks: boolean;
+}
+
 interface CommandContextBase {
   debug: boolean;
-  output: string | undefined;
   quiet: boolean;
 }
 
@@ -45,19 +62,20 @@ interface CommandContextNamed extends CommandContextBase {
   moduleName: string;
 }
 
-export interface CommandContextFilter extends CommandContextBase, InputContext, FilterFlags, SortFlags {
+export interface CommandContextFilter extends CommandContextBase, FileContext, FilterFlags, SortFlags {
   exclude: string[] | undefined;
   include: string[] | undefined;
   maxCount: number | undefined;
   repositoryPrefix: string[] | undefined;
   targetVersion: string | undefined;
 }
-export interface CommandContextInit extends CommandContextNamed, DownloadFlags, FilterFlags, SortFlags {}
-export interface CommandContextRefresh extends CommandContextBase, DownloadFlags, InputContext {
+export interface CommandContextFormat extends CommandContextBase, InputContext, FormatContext {}
+export interface CommandContextInit extends CommandContextNamed, OutputContext, DownloadFlags, FilterFlags, SortFlags {}
+export interface CommandContextRefresh extends CommandContextBase, DownloadFlags, FileContext {
   check: boolean | undefined;
   moduleName: string | undefined;
 }
-export interface CommandContextLookup extends CommandContextNamed, DownloadFlags, FilterFlags, InputContext {
+export interface CommandContextLookup extends CommandContextNamed, DownloadFlags, FilterFlags, FileContext {
   check: boolean | undefined;
   includeHistoric: boolean | undefined;
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,10 +1,10 @@
+import { isErrorWithCode } from '@voxpelli/typed-utils';
 import chalk from 'chalk';
 import { peowlyCommands } from 'peowly-commands';
 import { messageWithCauses, stackWithCauses } from 'pony-cause';
 
 import { cliCommands } from './commands/index.js';
 import { InputError, ResultError } from './utils/errors.js';
-import { isErrorWithCode } from './utils/typed-utils.js';
 
 export async function cli () {
   try {

--- a/lib/commands/filter.js
+++ b/lib/commands/filter.js
@@ -1,6 +1,7 @@
 import { copyFile } from 'node:fs/promises';
 import { pipeline } from 'node:stream/promises';
 
+import { omit } from '@voxpelli/typed-utils';
 import { oraPromise } from 'ora';
 import { peowly } from 'peowly';
 import { temporaryFileTask } from 'tempy';
@@ -9,7 +10,6 @@ import { baseFlags, sortFlags } from '../flags/misc.js';
 import { ndjsonOutput, ndjsonParse } from '../utils/ndjson.js';
 import { InputError } from '../utils/errors.js';
 import { arrayFromAsync, sortByKey } from '../utils/misc.js';
-import { omit } from '../utils/typed-utils.js';
 import { inputFlags, outputFlags, validateFileFlags } from '../flags/file.js';
 import { filterFlags, validateFilterFlags } from '../flags/filter.js';
 import { includeByAge, includeByDownloads, includeByRepositoryPrefix, includeByTargetVersion } from '../filters.js';

--- a/lib/commands/filter.js
+++ b/lib/commands/filter.js
@@ -1,4 +1,5 @@
 import { copyFile } from 'node:fs/promises';
+import { stdout } from 'node:process';
 import { pipeline } from 'node:stream/promises';
 
 import { omit } from '@voxpelli/typed-utils';
@@ -6,13 +7,14 @@ import { oraPromise } from 'ora';
 import { peowly } from 'peowly';
 import { temporaryFileTask } from 'tempy';
 
-import { baseFlags, sortFlags } from '../flags/misc.js';
+import { baseFlags, formatFlags, sortFlags } from '../flags/misc.js';
 import { ndjsonOutput, ndjsonParse } from '../utils/ndjson.js';
 import { InputError } from '../utils/errors.js';
 import { arrayFromAsync, sortByKey } from '../utils/misc.js';
 import { inputFlags, outputFlags, validateFileFlags } from '../flags/file.js';
 import { filterFlags, validateFilterFlags } from '../flags/filter.js';
 import { includeByAge, includeByDownloads, includeByRepositoryPrefix, includeByTargetVersion } from '../filters.js';
+import { formatList } from '../utils/format.js';
 
 /** @type {import('peowly-commands').CliCommand} */
 export const filter = {
@@ -27,7 +29,7 @@ export const filter = {
         spinner => temporaryFileTask(tmpFile => processData(spinner, tmpFile, context)),
         {
           prefixText: 'Processing data',
-          isSilent: !context.output || context.quiet,
+          isSilent: !context.output || context.quiet || context.markdown || context.prettyPrint,
         }
       )
         .catch(/** @param {unknown} cause */ cause => {
@@ -52,6 +54,7 @@ async function setupCommand (name, description, args, { pkg }) {
     ...inputFlags,
     ...omit(outputFlags, ['named']),
     ...filterFlags,
+    ...formatFlags,
     ...sortFlags,
     exclude: {
       description: 'The name or repository url of a module to exclude (repeatable)',
@@ -70,6 +73,12 @@ async function setupCommand (name, description, args, { pkg }) {
       listGroup: 'Filter options',
       type: 'string',
     },
+    'pretty-print': {
+      description: 'Pretty print the output',
+      listGroup: 'Format options',
+      type: 'boolean',
+      'default': false,
+    },
     'repository-prefix': {
       description: 'Required repository prefix',
       listGroup: 'Filter options',
@@ -87,8 +96,12 @@ async function setupCommand (name, description, args, { pkg }) {
     flags: {
       debug,
       exclude,
+      field: pkgFields,
       include,
+      markdown,
       'max-count': rawMaxCount,
+      'no-links': skipLinks,
+      'pretty-print': prettyPrint,
       quiet,
       'repository-prefix': repositoryPrefix,
       sort,
@@ -124,14 +137,22 @@ async function setupCommand (name, description, args, { pkg }) {
     throw new InputError('Expected --max-count to be numeric');
   }
 
+  if (!markdown && !prettyPrint && (pkgFields || skipLinks)) {
+    throw new InputError('--field / --no-links are only possible to combine with --markdown / --pretty-print');
+  }
+
   /** @type {import('../cli-types.d.ts').CommandContextFilter} */
   const result = {
     debug,
     exclude,
     include,
+    markdown,
     maxCount,
-    repositoryPrefix,
+    pkgFields,
+    prettyPrint,
     quiet,
+    repositoryPrefix,
+    skipLinks,
     sort,
     sortDependents,
     sortDownloads,
@@ -160,12 +181,16 @@ async function processData (spinner, tmpFile, context) {
     exclude = [],
     include,
     input,
+    markdown,
     maxAge,
     maxCount = Number.POSITIVE_INFINITY,
     minDownloads,
     modifyInPlace,
     output,
+    pkgFields,
+    prettyPrint,
     repositoryPrefix,
+    skipLinks,
     sort,
     sortDependents,
     sortDownloads,
@@ -176,7 +201,7 @@ async function processData (spinner, tmpFile, context) {
     throw new InputError('No input given');
   }
 
-  const streaming = !sort && !sortDependents && !sortDownloads && include;
+  const streaming = !sort && !sortDependents && !sortDownloads && !markdown && !prettyPrint && include;
 
   /** @type {import('../cli-types.d.ts').CliDependentsItem[]|undefined} */
   let result;
@@ -290,7 +315,19 @@ async function processData (spinner, tmpFile, context) {
       }
     }
 
-    await ndjsonOutput(finalResult, output);
+    // eslint-disable-next-line unicorn/prefer-ternary
+    if (markdown || prettyPrint) {
+      await pipeline(
+        formatList(finalResult, {
+          markdown,
+          pkgFields,
+          skipLinks,
+        }),
+        stdout
+      );
+    } else {
+      await ndjsonOutput(finalResult, output);
+    }
   } else if (modifyInPlace && output) {
     await copyFile(tmpFile, output);
   }

--- a/lib/commands/format.js
+++ b/lib/commands/format.js
@@ -1,3 +1,4 @@
+import { stdout } from 'node:process';
 import { pipeline } from 'node:stream/promises';
 
 import { peowly } from 'peowly';
@@ -101,8 +102,9 @@ async function commandAction (context) {
   await pipeline(
     input,
     ndjsonParse,
-    async collection => {
-      await formatList(collection, formatContext);
-    }
+    async function * (collection) {
+      yield * formatList(collection, formatContext);
+    },
+    stdout
   );
 }

--- a/lib/commands/format.js
+++ b/lib/commands/format.js
@@ -1,0 +1,108 @@
+import { pipeline } from 'node:stream/promises';
+
+import { peowly } from 'peowly';
+
+import { inputFlags, validateInputFlags } from '../flags/file.js';
+import { baseFlags, formatFlags } from '../flags/misc.js';
+import { ndjsonParse } from '../utils/ndjson.js';
+import { InputError } from '../utils/errors.js';
+import { formatList } from '../utils/format.js';
+
+/** @type {import('peowly-commands').CliCommand} */
+export const format = {
+  description: 'Pretty prints a list of dependents',
+  async run (argv, meta, { parentName }) {
+    const name = parentName + ' format';
+
+    const context = await setupCommand(name, format.description, argv, meta);
+
+    await commandAction(context);
+  },
+};
+
+// Internal functions
+
+/**
+ * @param {string} name
+ * @param {string} description
+ * @param {string[]} args
+ * @param {import('peowly-commands').CliMeta} meta
+ * @returns {Promise<import('../cli-types.d.ts').CommandContextFormat>}
+ */
+async function setupCommand (name, description, args, { pkg }) {
+  const options = /** @satisfies {import('peowly').AnyFlags} */ ({
+    ...baseFlags,
+    ...formatFlags,
+    ...inputFlags,
+  });
+
+  const {
+    flags: {
+      debug,
+      field: pkgFields,
+      markdown,
+      'no-links': skipLinks,
+      quiet,
+      ...remainingFlags
+    },
+    input: [targetFile, ...otherInput],
+    showHelp,
+  } = peowly({
+    args,
+    description,
+    examples: [
+      '-i input-file.ndjson',
+      'input-file.ndjson',
+      { prefix: 'cat input-file.ndjson |' },
+    ],
+    name,
+    options,
+    pkg,
+    usage: '[input-file.ndjson]',
+  });
+
+  if (otherInput.length > 0) {
+    throw new InputError('Only one input file is supported');
+  }
+
+  /** @type {import('../cli-types.d.ts').CommandContextFormat} */
+  const result = {
+    debug,
+    markdown,
+    pkgFields,
+    quiet,
+    skipLinks,
+    ...validateInputFlags(remainingFlags, targetFile),
+  };
+
+  if (!result.input) {
+    showHelp();
+    // eslint-disable-next-line unicorn/no-process-exit
+    process.exit();
+  }
+
+  return result;
+}
+
+/**
+ * @param {import('../cli-types.d.ts').CommandContextFormat} context
+ * @returns {Promise<void>}
+ */
+async function commandAction (context) {
+  const {
+    input,
+    ...formatContext
+  } = context;
+
+  if (!input) {
+    throw new InputError('No input given');
+  }
+
+  await pipeline(
+    input,
+    ndjsonParse,
+    async collection => {
+      await formatList(collection, formatContext);
+    }
+  );
+}

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,5 +1,11 @@
 import { filter } from './filter.js';
+import { format } from './format.js';
 import { list } from './list.js';
 import { refresh } from './refresh.js';
 
-export const cliCommands = { filter, list, refresh };
+export const cliCommands = {
+  filter,
+  format,
+  list,
+  refresh,
+};

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -1,6 +1,7 @@
 import { pipeline } from 'node:stream/promises';
 import { isDeepStrictEqual } from 'node:util';
 
+import { looksLikeAnErrnoException } from '@voxpelli/typed-utils';
 import createLogger from 'bunyan-adaptor';
 import { fetchEcosystemDependents } from 'list-dependents';
 import { oraPromise } from 'ora';
@@ -11,7 +12,6 @@ import { downloadFlags, validateDownloadFlags } from '../flags/download.js';
 import { InputError, ResultError } from '../utils/errors.js';
 import { formatItems } from '../utils/fields.js';
 import { ndjsonOutput, ndjsonParse } from '../utils/ndjson.js';
-import { looksLikeAnErrnoException } from '../utils/typed-utils.js';
 import { inputFlags, outputFlags, validateFileFlags } from '../flags/file.js';
 import { filterFlags, validateFilterFlags } from '../flags/filter.js';
 import { formatSummary } from '../utils/summary.js';

--- a/lib/commands/refresh.js
+++ b/lib/commands/refresh.js
@@ -2,6 +2,7 @@ import { copyFile } from 'node:fs/promises';
 import { pipeline } from 'node:stream/promises';
 import { isDeepStrictEqual } from 'node:util';
 
+import { omit } from '@voxpelli/typed-utils';
 import { bufferedAsyncMap } from 'buffered-async-iterable';
 import createLogger from 'bunyan-adaptor';
 import { createPackageFetchQueue } from 'list-dependents';
@@ -14,7 +15,6 @@ import { downloadFlags, validateDownloadFlags } from '../flags/download.js';
 import { InputError, ResultError } from '../utils/errors.js';
 import { formatItem } from '../utils/fields.js';
 import { ndjsonOutput, ndjsonParse } from '../utils/ndjson.js';
-import { omit } from '../utils/typed-utils.js';
 import { inputFlags, outputFlags, validateFileFlags } from '../flags/file.js';
 
 /** @type {import('peowly-commands').CliCommand} */

--- a/lib/flags/file.js
+++ b/lib/flags/file.js
@@ -4,6 +4,8 @@ import { cwd, stdin } from 'node:process';
 
 import { InputError } from '../utils/errors.js';
 
+/** @import { InputContext, FileContext, OutputContext } from '../cli-types.d.ts' */
+
 export const inputFlags = /** @satisfies {Record<string, import("peowly").AnyFlag & { listGroup: 'File options' }>} */ ({
   input: {
     description: 'Read data from the specified file',
@@ -33,29 +35,72 @@ export const outputFlags = /** @satisfies {Record<string, import("peowly").AnyFl
 /** @typedef {import("peowly").TypedFlags<typeof outputFlags>} OutputFlags */
 
 /**
- * @typedef FileFlags
- * @property {string|undefined} output
+ * @overload
+ * @param {InputFlags} flags
+ * @param {string|undefined} [targetFile]
+ * @returns {InputContext}
  */
+/**
+ * @overload
+ * @param {Partial<InputFlags>} flags
+ * @param {string|undefined} targetFile
+ * @param {{ namedOutput: string|undefined, filePath: string|undefined }} output
+ * @returns {FileContext}
+ */
+/**
+ * @param {Partial<InputFlags>} flags
+ * @param {string|undefined} [targetFile]
+ * @param {{ namedOutput: string|undefined, filePath: string|undefined }} [output]
+ * @returns {Partial<FileContext> & InputContext}
+ */
+export function validateInputFlags (flags, targetFile, output) {
+  const {
+    input: inputFlag,
+  } = flags;
+
+  const inputFile = targetFile || inputFlag || output?.namedOutput;
+
+  const resolvedInputFile = inputFile ? path.resolve(cwd(), inputFile) : undefined;
+
+  const input = resolvedInputFile
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    ? createReadStream(resolvedInputFile, 'utf8')
+    : (stdin.isTTY ? undefined : stdin);
+
+  if (output) {
+    return {
+      explicitInput: inputFile !== undefined && inputFile === inputFlag,
+      input,
+      modifyInPlace: resolvedInputFile ? resolvedInputFile === output?.filePath : false,
+      output: output?.filePath,
+    };
+  }
+
+  return {
+    explicitInput: inputFile !== undefined && inputFile === inputFlag,
+    input,
+  };
+}
 
 /**
  * @overload
  * @param {InputFlags & OutputFlags} flags
  * @param {string|undefined} [targetFile]
  * @param {string} [moduleName]
- * @returns {import('../cli-types.d.ts').InputContext & { output: string|undefined }}
+ * @returns {FileContext}
  */
 /**
  * @overload
  * @param {OutputFlags} flags
  * @param {string|undefined} [targetFile]
  * @param {string} [moduleName]
- * @returns {{ output: string|undefined }}
+ * @returns {OutputContext}
  */
 /**
  * @param {Partial<InputFlags> & OutputFlags} flags
  * @param {string|undefined} [targetFile]
  * @param {string} [moduleName]
- * @returns {Partial<import('../cli-types.d.ts').InputContext> & { output: string|undefined }}
+ * @returns {Partial<FileContext> & OutputContext}
  */
 export function validateFileFlags (flags, targetFile, moduleName) {
   const {
@@ -86,25 +131,13 @@ export function validateFileFlags (flags, targetFile, moduleName) {
 
   const namedOutput = (named && moduleName) ? `${moduleName.replaceAll('/', '__').replaceAll('@', '')}.ndjson` : undefined;
 
-  const inputFile = targetFile || inputFlag || namedOutput;
   const outputFile = targetFile || outputFlag || namedOutput;
 
-  const resolvedInputFile = inputFile ? path.resolve(cwd(), inputFile) : undefined;
   const output = outputFile ? path.resolve(cwd(), outputFile) : undefined;
 
   if (!('input' in flags)) {
     return { output };
   }
 
-  const input = resolvedInputFile
-    // eslint-disable-next-line security/detect-non-literal-fs-filename
-    ? createReadStream(resolvedInputFile, 'utf8')
-    : (stdin.isTTY ? undefined : stdin);
-
-  return {
-    explicitInput: inputFile !== undefined && inputFile === inputFlag,
-    input,
-    modifyInPlace: resolvedInputFile ? resolvedInputFile === output : false,
-    output,
-  };
+  return validateInputFlags(flags, targetFile, { namedOutput, filePath: output });
 }

--- a/lib/flags/misc.js
+++ b/lib/flags/misc.js
@@ -13,6 +13,27 @@ export const baseFlags = /** @satisfies {Record<string, import("peowly").AnyFlag
   },
 });
 
+export const formatFlags = /** @satisfies {Record<string, import("peowly").AnyFlag & { listGroup: 'Format options' }>} */ ({
+  field: {
+    description: 'Narrow down which package.json fields to include (supports dot-separated paths)',
+    listGroup: 'Format options',
+    multiple: true,
+    type: 'string',
+  },
+  markdown: {
+    description: 'Format output as markdown',
+    listGroup: 'Format options',
+    type: 'boolean',
+    'default': false,
+  },
+  'no-links': {
+    description: 'Avoids adding links to the output',
+    listGroup: 'Format options',
+    type: 'boolean',
+    'default': false,
+  },
+});
+
 export const sortFlags = /** @satisfies {Record<string, import("peowly").AnyFlag & { listGroup: 'Sort options' }>} */ ({
   sort: {
     description: 'Sort by name',

--- a/lib/utils/fields.js
+++ b/lib/utils/fields.js
@@ -1,5 +1,6 @@
+import { pick } from '@voxpelli/typed-utils';
+
 import { precision } from './misc.js';
-import { pick } from './typed-utils.js';
 
 /**
  * @typedef ItemFormatOptions

--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -1,0 +1,169 @@
+/* eslint-disable no-console */
+
+import { semverIntersect } from '@voxpelli/semver-set';
+import { getObjectValueByPath, getValueByPath } from '@voxpelli/typed-utils';
+import {
+  MarkdownOrChalk,
+  mdastLinkify,
+  mdastTableHelper,
+} from 'markdown-or-chalk';
+import { minVersion } from 'semver';
+
+import { getStringLikeValueByPath } from '../utils/typed-utils.js';
+
+/** @typedef {import('markdown-or-chalk').PhrasingContentOrStringList} PhrasingContentOrStringList */
+/** @typedef {[PhrasingContentOrStringList, string, string, ...PhrasingContentOrStringList[]]} TableRow */
+
+/**
+ * @param {AsyncIterable<unknown>} collection
+ * @param {import('../cli-types.d.ts').FormatContext} context
+ * @returns {Promise<void>}
+ */
+export async function formatList (collection, context) {
+  const {
+    markdown,
+    pkgFields = [],
+    skipLinks,
+  } = context;
+
+  const format = new MarkdownOrChalk(markdown);
+
+  /** @type {TableRow[]} */
+  const tableData = [
+    ['Name', 'Dependents', 'Downloads', ...pkgFields],
+  ];
+
+  /** @type {Record<string, string|undefined>} */
+  const fieldSemVerIntersection = {};
+
+  /** @type {Record<string, import('semver').SemVer|undefined>} */
+  const fieldSemVerMin = {};
+
+  /** @type {Record<string, string[]>} */
+  const fieldSemVerMinNames = {};
+
+  /** @type {Record<string, string[]>} */
+  const fieldSemVerMinMajorNames = {};
+
+  for (const field of pkgFields) {
+    if (
+      field.startsWith('engines.') ||
+      field.startsWith('dependencies.') ||
+      field.startsWith('devDependencies.') ||
+      field.startsWith('peerDependencies.')
+    ) {
+      fieldSemVerIntersection[field] = '*';
+      fieldSemVerMin[field] = undefined;
+    }
+  }
+
+  for await (const item of collection) {
+    const name = getStringLikeValueByPath(item, 'name');
+
+    if (!name) {
+      continue;
+    }
+
+    const pkg = pkgFields.length ? getObjectValueByPath(item, 'pkg') : undefined;
+
+    /** @type {TableRow} */
+    const row = [
+      mdastLinkify(name, `https://www.npmjs.com/package/${name}`, skipLinks),
+      getStringLikeValueByPath(item, 'dependentCount') || '',
+      getStringLikeValueByPath(item, 'downloads') || '',
+    ];
+
+    for (const field of pkgFields) {
+      const pathValue = getValueByPath(pkg, field.split('.'));
+
+      if (!pathValue) {
+        row.push('-');
+        continue;
+      }
+
+      if (typeof pathValue.value !== 'string') {
+        row.push([{
+          type: 'inlineCode',
+          value: JSON.stringify(pathValue.value),
+        }]);
+        continue;
+      }
+
+      row.push([{ type: 'inlineCode', value: pathValue.value }]);
+
+      if (fieldSemVerIntersection[field]) {
+        fieldSemVerIntersection[field] = semverIntersect(fieldSemVerIntersection[field], pathValue.value, { loose: true });
+      }
+
+      const min = minVersion(pathValue.value);
+
+      if (min) {
+        const comparison = fieldSemVerMin[field]?.compare(min);
+
+        if (comparison === undefined || comparison === 1) {
+          fieldSemVerMinMajorNames[field] = fieldSemVerMin[field]?.major === min.major
+            ? [
+                ...fieldSemVerMinMajorNames[field] || [],
+                ...fieldSemVerMinNames[field] || [],
+              ]
+            : [];
+
+          fieldSemVerMin[field] = min;
+          fieldSemVerMinNames[field] = [name];
+        } else if (comparison === 0) {
+          fieldSemVerMinNames[field]?.push(name);
+        }
+      }
+    }
+
+    tableData.push(row);
+  }
+
+  console.log(format.header('Modules'));
+
+  console.log(format.fromMdast(mdastTableHelper(
+    tableData,
+    ['left', 'right', 'right', ...pkgFields.map(() => /** @type {const} */ ('center'))]
+  )));
+
+  /** @type {string[]} */
+  const intersections = [];
+
+  for (const [field, intersection] of Object.entries(fieldSemVerIntersection)) {
+    if (intersection !== '*') {
+      intersections.push(format.bold(field) + ': ' + (intersection || 'no overlapping version ranges'));
+    }
+  }
+
+  if (intersections.length) {
+    console.log(format.header('Intersection of versions', 2));
+    for (const item of intersections) {
+      console.log(item);
+    }
+  }
+
+  /** @type {string[]} */
+  const minVersions = [];
+
+  for (const [field, min] of Object.entries(fieldSemVerMin)) {
+    minVersions.push(
+      format.bold(field) + ': ' + (
+        min
+          ? min.format() + ' ' + format.italic(`(${fieldSemVerMinNames[field]?.join(', ')})`) +
+            (
+              fieldSemVerMinMajorNames[field]?.length
+                ? ' ' + format.italic(`(Also including some ${min.major}.x.x release: ${fieldSemVerMinMajorNames[field]?.join(', ')})`)
+                : ''
+            )
+          : 'no min version'
+      )
+    );
+  }
+
+  if (minVersions.length) {
+    console.log(format.header('Lowest included versions', 2));
+    for (const item of minVersions) {
+      console.log(item);
+    }
+  }
+}

--- a/lib/utils/format.js
+++ b/lib/utils/format.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 import { semverIntersect } from '@voxpelli/semver-set';
 import { getObjectValueByPath, getValueByPath } from '@voxpelli/typed-utils';
 import {
@@ -15,11 +13,11 @@ import { getStringLikeValueByPath } from '../utils/typed-utils.js';
 /** @typedef {[PhrasingContentOrStringList, string, string, ...PhrasingContentOrStringList[]]} TableRow */
 
 /**
- * @param {AsyncIterable<unknown>} collection
+ * @param {AsyncIterable<unknown>|import('../cli-types.d.ts').CliDependentsItem[]} collection
  * @param {import('../cli-types.d.ts').FormatContext} context
- * @returns {Promise<void>}
+ * @returns {AsyncGenerator<string, void, undefined>}
  */
-export async function formatList (collection, context) {
+export async function * formatList (collection, context) {
   const {
     markdown,
     pkgFields = [],
@@ -119,12 +117,12 @@ export async function formatList (collection, context) {
     tableData.push(row);
   }
 
-  console.log(format.header('Modules'));
+  yield format.header('Modules') + '\n';
 
-  console.log(format.fromMdast(mdastTableHelper(
+  yield format.fromMdast(mdastTableHelper(
     tableData,
     ['left', 'right', 'right', ...pkgFields.map(() => /** @type {const} */ ('center'))]
-  )));
+  )) + '\n';
 
   /** @type {string[]} */
   const intersections = [];
@@ -136,9 +134,9 @@ export async function formatList (collection, context) {
   }
 
   if (intersections.length) {
-    console.log(format.header('Intersection of versions', 2));
+    yield format.header('Intersection of versions', 2) + '\n';
     for (const item of intersections) {
-      console.log(item);
+      yield item + '\n';
     }
   }
 
@@ -161,9 +159,9 @@ export async function formatList (collection, context) {
   }
 
   if (minVersions.length) {
-    console.log(format.header('Lowest included versions', 2));
+    yield format.header('Lowest included versions', 2) + '\n';
     for (const item of minVersions) {
-      console.log(item);
+      yield item + '\n';
     }
   }
 }

--- a/lib/utils/typed-utils.js
+++ b/lib/utils/typed-utils.js
@@ -1,54 +1,23 @@
-// Copied from @voxpelli/typed-utils
+import { getValueByPath } from '@voxpelli/typed-utils';
 
 /**
- * @param {unknown} value
- * @returns {value is Error & { code: string }}
+ * @param {unknown} obj
+ * @param {string[]|string} path
+ * @returns {string|undefined|false}
  */
-export function isErrorWithCode (value) {
-  return value instanceof Error && 'code' in value;
-}
+export function getStringLikeValueByPath (obj, path) {
+  const result = getValueByPath(obj, path);
 
-/**
- * @param {unknown} value
- * @returns {value is NodeJS.ErrnoException & { code: string, path: string }}
- */
-export function looksLikeAnErrnoException (value) {
-  return isErrorWithCode(value) && 'path' in value;
-}
-
-/**
- * @template {object} T
- * @template {keyof T} K
- * @param {T} input
- * @param {K[]|ReadonlyArray<K>} keys
- * @returns {Pick<T, K>}
- */
-export function pick (input, keys) {
-  /** @type {Partial<Pick<T, K>>} */
-  const result = {};
-
-  for (const key of keys) {
-    if (key in input) {
-      result[key] = input[key];
-    }
+  if (typeof result !== 'object') {
+    return result;
   }
 
-  return /** @type {Pick<T, K>} */ (result);
-}
-
-/**
- * @template {object} T
- * @template {keyof T} K
- * @param {T} input
- * @param {K[]|ReadonlyArray<K>} keys
- * @returns {Omit<T, K>}
- */
-export function omit (input, keys) {
-  const result = { ...input };
-
-  for (const key of keys) {
-    delete result[key];
+  switch (typeof result.value) {
+    case 'string':
+      return result.value;
+    case 'number':
+      return `${result.value}`;
+    default:
+      return false;
   }
-
-  return result;
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lib/**/*.js"
   ],
   "scripts": {
-    "check:installed-check": "installed-check -i type-coverage -i @voxpelli/eslint-config -i eslint",
+    "check:installed-check": "installed-check -i type-coverage -i @voxpelli/eslint-config -i eslint -i @voxpelli/semver-set",
     "check:knip": "knip",
     "check:lint": "eslint --report-unused-disable-directives .",
     "check:tsc": "tsc",
@@ -47,15 +47,18 @@
     "validate-conventional-commit": "^1.0.4"
   },
   "dependencies": {
+    "@voxpelli/semver-set": "^6.0.0",
+    "@voxpelli/typed-utils": "^1.10.2",
     "buffered-async-iterable": "^1.0.0",
     "bunyan-adaptor": "^6.0.1",
     "chalk": "^5.3.0",
     "list-dependents": "^2.2.2",
+    "markdown-or-chalk": "^0.2.3",
     "ora": "^8.0.1",
     "peowly": "^1.3.2",
     "peowly-commands": "^1.1.0",
     "pony-cause": "^2.1.11",
-    "semver": "^7.6.2",
+    "semver": "^7.6.3",
     "tempy": "^3.1.0"
   }
 }


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and flexibility of the CLI commands and their associated flags. The most important changes include the addition of a new `format` command, updates to the `filter` command to support new formatting options, and the reorganization of utility imports.

### New Features:
* [`lib/commands/format.js`](diffhunk://#diff-f515928f4a8fa4b1fa904ced9e754b700b44c620a1ea810df2fc03350f5eb2caR1-R110): Introduced a new `format` command that pretty prints a list of dependents.
* [`lib/commands/index.js`](diffhunk://#diff-0b2a75c1dc7b3098aaced25a55b90953dd06e6f613034eb30645a44ed3142b08R2-R11): Added the new `format` command to the list of CLI commands.

### Enhancements to Existing Commands:
* [`lib/commands/filter.js`](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20L30-R32): Updated the `filter` command to include new flags for formatting options (`--pretty-print`, `--markdown`, `--field`, `--no-links`). These changes allow for more flexible output formatting. [[1]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20L30-R32) [[2]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R57) [[3]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R76-R81) [[4]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R99-R104) [[5]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R140-R155) [[6]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R184-R193) [[7]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20L179-R204) [[8]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R318-R330)

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39): Added documentation for the new `list-dependents format` command.

### Dependency and Import Management:
* Various files (`lib/cli.js`, `lib/commands/filter.js`, `lib/commands/list.js`, `lib/commands/refresh.js`, `lib/utils/fields.js`): Reorganized imports to use utility functions from the `@voxpelli/typed-utils` package, removing redundant local utility imports. [[1]](diffhunk://#diff-347ff93ed2b00c93c817863e32fbac5b4fac71d7339a48378980e682777689f4R1-L7) [[2]](diffhunk://#diff-4b06f530740396ac9582d31d5d14ea62a5e614b867b2c1c957ff1dcc23fb0e4cR4) [[3]](diffhunk://#diff-4b06f530740396ac9582d31d5d14ea62a5e614b867b2c1c957ff1dcc23fb0e4cL14) [[4]](diffhunk://#diff-37bc9e934bb5310daec567c6357df74ace51dcc947bdcddb953c6df6421415efR5) [[5]](diffhunk://#diff-37bc9e934bb5310daec567c6357df74ace51dcc947bdcddb953c6df6421415efL17) [[6]](diffhunk://#diff-fb916ee5034afb51cfd2762eb5c9f5df085e2500636e34239fc6c95dc23fcc3dR1-L2)

### Configuration Updates:
* [`.github/workflows/ts-internal.yml`](diffhunk://#diff-13d7f3d630380c591fd751956dfe32ab124b1db1bff4c4b9855464f76cce98a8L22-R22): Updated the TypeScript versions used in the type-check workflow from `5.4,next` to `5.6,next`.