### PR TITLE
feat: `--no-additions` flag on `filter` command

### DIFF
--- a/lib/cli-types.d.ts
+++ b/lib/cli-types.d.ts
@@ -68,6 +68,7 @@ export interface CommandContextFilter extends CommandContextBase, FileContext, F
   maxCount: number | undefined;
   prettyPrint: boolean;
   repositoryPrefix: string[] | undefined;
+  skipAdditions: boolean;
   targetVersion: string | undefined;
 }
 export interface CommandContextFormat extends CommandContextBase, InputContext, FormatContext {}

--- a/lib/commands/filter.js
+++ b/lib/commands/filter.js
@@ -15,6 +15,7 @@ import { inputFlags, outputFlags, validateFileFlags } from '../flags/file.js';
 import { filterFlags, validateFilterFlags } from '../flags/filter.js';
 import { includeByAge, includeByDownloads, includeByRepositoryPrefix, includeByTargetVersion } from '../filters.js';
 import { formatList } from '../utils/format.js';
+import { readDependentsCollection } from '../utils/read.js';
 
 /** @type {import('peowly-commands').CliCommand} */
 export const filter = {
@@ -73,6 +74,12 @@ async function setupCommand (name, description, args, { pkg }) {
       listGroup: 'Filter options',
       type: 'string',
     },
+    'no-additions': {
+      description: 'Avoids adding any new repositories to the output',
+      listGroup: 'Filter options',
+      type: 'boolean',
+      'default': false,
+    },
     'pretty-print': {
       description: 'Pretty print the output',
       listGroup: 'Format options',
@@ -100,6 +107,7 @@ async function setupCommand (name, description, args, { pkg }) {
       include,
       markdown,
       'max-count': rawMaxCount,
+      'no-additions': skipAdditions,
       'no-links': skipLinks,
       'pretty-print': prettyPrint,
       quiet,
@@ -152,6 +160,7 @@ async function setupCommand (name, description, args, { pkg }) {
     prettyPrint,
     quiet,
     repositoryPrefix,
+    skipAdditions,
     skipLinks,
     sort,
     sortDependents,
@@ -160,6 +169,14 @@ async function setupCommand (name, description, args, { pkg }) {
     ...validateFileFlags({ ...remainingFlags, named: false }, targetFile),
     ...validateFilterFlags(remainingFlags),
   };
+
+  if (skipAdditions) {
+    if (!result.output) {
+      throw new InputError('--no-additions requires an output file');
+    } else if (result.modifyInPlace) {
+      throw new InputError('--no-additions requires an output file separate from the input');
+    }
+  }
 
   if (!result.input) {
     showHelp();
@@ -185,11 +202,11 @@ async function processData (spinner, tmpFile, context) {
     maxAge,
     maxCount = Number.POSITIVE_INFINITY,
     minDownloads,
-    modifyInPlace,
     output,
     pkgFields,
     prettyPrint,
     repositoryPrefix,
+    skipAdditions,
     skipLinks,
     sort,
     sortDependents,
@@ -201,12 +218,18 @@ async function processData (spinner, tmpFile, context) {
     throw new InputError('No input given');
   }
 
+  const modifyInPlace = context.modifyInPlace || skipAdditions;
   const streaming = !sort && !sortDependents && !sortDownloads && !markdown && !prettyPrint && include;
+
+  const existingItems = skipAdditions && output
+    ? new Set(Object.keys(await readDependentsCollection(output)))
+    : undefined;
 
   /** @type {import('../cli-types.d.ts').CliDependentsItem[]|undefined} */
   let result;
   let count = 0;
   let included = 0;
+  let skipped = 0;
 
   await pipeline(
     input,
@@ -234,11 +257,17 @@ async function processData (spinner, tmpFile, context) {
           includeByRepositoryPrefix(item, repositoryPrefix) &&
           includeByTargetVersion(item, targetVersion)
         ) {
-          included += 1;
-          yield /** @type {import('../cli-types.d.ts').CliDependentsItem} */ (item);
+          if (skipAdditions && !existingItems?.has(item.name)) {
+            skipped += 1;
+          } else {
+            included += 1;
+            yield /** @type {import('../cli-types.d.ts').CliDependentsItem} */ (item);
+          }
         }
 
-        spinner.text = `Processed ${count} items, included ${included} items, filtered ${count - included} items`;
+        spinner.text = `Processed ${count} items, included ${included} items${
+          skipped ? `, skipped ${skipped} items` : ''
+        }, filtered ${count - included - skipped} items`;
 
         if (included > maxCount && streaming) {
           break;

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -1,4 +1,3 @@
-import { pipeline } from 'node:stream/promises';
 import { isDeepStrictEqual } from 'node:util';
 
 import { looksLikeAnErrnoException } from '@voxpelli/typed-utils';
@@ -11,10 +10,11 @@ import { baseFlags } from '../flags/misc.js';
 import { downloadFlags, validateDownloadFlags } from '../flags/download.js';
 import { InputError, ResultError } from '../utils/errors.js';
 import { formatItems } from '../utils/fields.js';
-import { ndjsonOutput, ndjsonParse } from '../utils/ndjson.js';
+import { ndjsonOutput } from '../utils/ndjson.js';
 import { inputFlags, outputFlags, validateFileFlags } from '../flags/file.js';
 import { filterFlags, validateFilterFlags } from '../flags/filter.js';
 import { formatSummary } from '../utils/summary.js';
+import { readDependentsCollection } from '../utils/read.js';
 
 /** @type {import('peowly-commands').CliCommand} */
 export const list = {
@@ -39,7 +39,7 @@ export const list = {
 
     const itemsByName = input && await (
       oraPromise(
-        spinner => readData(spinner, input),
+        spinner => readDependentsCollection(input, spinner),
         {
           prefixText: `Reading existing dependents data for ${moduleName}`,
           isSilent: !output || quiet,
@@ -149,36 +149,6 @@ async function setupCommand (name, description, args, { pkg }) {
   };
 
   return result;
-}
-
-/**
- * @param {import('ora').Ora} spinner
- * @param {NonNullable<import('../cli-types.js').InputContext['input']>} source
- * @returns {Promise<import('../cli-types.js').CliDependentsCollection>}
- */
-async function readData (spinner, source) {
-  /** @type {import('../cli-types.js').CliDependentsCollection} */
-  const itemsByName = {};
-  let count = 0;
-
-  await pipeline(
-    source,
-    ndjsonParse,
-    async source => {
-      for await (const item of source) {
-        if (!item || typeof item !== 'object') {
-          continue;
-        }
-        if ('name' in item && typeof item.name === 'string') {
-          count += 1;
-          spinner.text = `Found ${count} existing dependents`;
-          itemsByName[item.name] = /** @type {import('../cli-types.js').CliDependentsItem} */ (item);
-        }
-      }
-    }
-  );
-
-  return itemsByName;
 }
 
 const summaryDescription = {

--- a/lib/utils/read.js
+++ b/lib/utils/read.js
@@ -1,0 +1,40 @@
+import { pipeline } from 'node:stream/promises';
+
+import { ndjsonParse } from './ndjson.js';
+import { createReadStream } from 'node:fs';
+/**
+ * @param {NonNullable<import('../cli-types.js').InputContext['input']> | string} source
+ * @param {import('ora').Ora} [spinner]
+ * @returns {Promise<import('../cli-types.js').CliDependentsCollection>}
+ */
+export async function readDependentsCollection (source, spinner) {
+  /** @type {import('../cli-types.js').CliDependentsCollection} */
+  const itemsByName = {};
+  let count = 0;
+
+  const rawSource = typeof source === 'string'
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    ? createReadStream(source, 'utf8')
+    : source;
+
+  await pipeline(
+    rawSource,
+    ndjsonParse,
+    async parsedSource => {
+      for await (const item of parsedSource) {
+        if (!item || typeof item !== 'object') {
+          continue;
+        }
+        if ('name' in item && typeof item.name === 'string') {
+          count += 1;
+          if (spinner) {
+            spinner.text = `Found ${count} existing dependents`;
+          }
+          itemsByName[item.name] = /** @type {import('../cli-types.js').CliDependentsItem} */ (item);
+        }
+      }
+    }
+  );
+
+  return itemsByName;
+}


### PR DESCRIPTION
This pull request introduces a new `--no-additions` flag to the `filter` command and refactors the code to use a new utility function for reading dependent collections. The most important changes include adding the new flag, updating the command setup and processing logic, and moving the dependent collection reading logic into a shared utility function.

### New `--no-additions` flag:

* [`lib/commands/filter.js`](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R77-R82): Added the `--no-additions` flag to the filter command options, ensuring that no new repositories are added to the output when this flag is set. [[1]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R77-R82) [[2]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R110) [[3]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R163) [[4]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R173-R180)

### Refactoring for dependent collection reading:

* [`lib/commands/filter.js`](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R221-R232): Updated the `processData` function to use the new `readDependentsCollection` utility function for reading existing items when the `--no-additions` flag is set. [[1]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R221-R232) [[2]](diffhunk://#diff-cd7e8f07ef997dea4c686db23c5913d52667c05bef3dfd869887c87566d7bd20R260-R270)
* [`lib/commands/list.js`](diffhunk://#diff-4b06f530740396ac9582d31d5d14ea62a5e614b867b2c1c957ff1dcc23fb0e4cL1): Replaced the inline data reading logic with the `readDependentsCollection` utility function. [[1]](diffhunk://#diff-4b06f530740396ac9582d31d5d14ea62a5e614b867b2c1c957ff1dcc23fb0e4cL1) [[2]](diffhunk://#diff-4b06f530740396ac9582d31d5d14ea62a5e614b867b2c1c957ff1dcc23fb0e4cL14-R17) [[3]](diffhunk://#diff-4b06f530740396ac9582d31d5d14ea62a5e614b867b2c1c957ff1dcc23fb0e4cL42-R42) [[4]](diffhunk://#diff-4b06f530740396ac9582d31d5d14ea62a5e614b867b2c1c957ff1dcc23fb0e4cL154-L183)
* [`lib/utils/read.js`](diffhunk://#diff-877171bb81fb02676ffc0a59687dbd10bce1c3e3b14b75485c75f5832237ecd8R1-R40): Added the `readDependentsCollection` utility function to centralize the logic for reading dependent collections from a source.